### PR TITLE
docs: Update outdated links to new github orga

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
   <img src="images/logo.png">
 </p>
 
-![terragrunt:env:demo](https://github.com/clusterfrak-dynamics/teks/workflows/terragrunt:env:demo/badge.svg)
-![teks:mkdocs](https://github.com/clusterfrak-dynamics/teks/workflows/teks:mkdocs/badge.svg)
+![terragrunt:env:demo](https://github.com/particuleio/teks/workflows/terragrunt:env:demo/badge.svg)
+![teks:mkdocs](https://github.com/particuleio/teks/workflows/teks:mkdocs/badge.svg)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fclusterfrak-dynamics%2Fteks.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fclusterfrak-dynamics%2Fteks?ref=badge_shield)
 
 tEKS is a set of Terraform / Terragrunt modules designed to get you everything you need to run a production EKS cluster on AWS. It ships with sensible defaults, and add a lot of common addons with their configurations that work out of the box.
 
-:warning: the v5 and further version of this project have been completely revamp and now offer a skeleton to use as a base for your infrastructure projects around EKS. All the modules have been moved outside this repository and get their own versioning. The [old README is accessible here](https://github.com/clusterfrak-dynamics/teks/tree/release-4.X)
+:warning: the v5 and further version of this project have been completely revamp and now offer a skeleton to use as a base for your infrastructure projects around EKS. All the modules have been moved outside this repository and get their own versioning. The [old README is accessible here](https://github.com/particuleio/teks/tree/release-4.X)
 
 ## Main purposes
 
@@ -23,15 +23,15 @@ A production cluster all defined in IaaC with Terraform/Terragrunt:
 
 * AWS VPC if needed based on [`terraform-aws-vpc`](https://github.com/terraform-aws-modules/terraform-aws-vpc)
 * EKS cluster base on [`terraform-aws-eks`](https://github.com/terraform-aws-modules/terraform-aws-eks)
-* Kubernetes addons based on [`terraform-kubernetes-addons`](https://github.com/clusterfrak-dynamics/terraform-kubernetes-addons): provides various addons that are often used on Kubernetes and specifically on EKS.
-* Kubernetes namespaces quota management based on [`terraform-kubernetes-namespaces`](https://github.com/clusterfrak-dynamics/terraform-kubernetes-addons): allows administrator to manage namespaces and quotas from a centralized configuration with Terraform.
-* AWS ECR registries management based on [`terraform-aws-ecr`](https://github.com/clusterfrak-dynamics/terraform-aws-ecr)
+* Kubernetes addons based on [`terraform-kubernetes-addons`](https://github.com/particuleio/terraform-kubernetes-addons): provides various addons that are often used on Kubernetes and specifically on EKS.
+* Kubernetes namespaces quota management based on [`terraform-kubernetes-namespaces`](https://github.com/particuleio/terraform-kubernetes-addons): allows administrator to manage namespaces and quotas from a centralized configuration with Terraform.
+* AWS ECR registries management based on [`terraform-aws-ecr`](https://github.com/particuleio/terraform-aws-ecr)
 
 Everything is tied together with Terragrunt and allows you to deploy a multi cluster architecture in a matter of minutes (ok maybe an hour) and different AWS accounts for different environments.
 
 ## Curated Features
 
-The main additionals features are the curated addons list, see [here](https://github.com/clusterfrak-dynamics/terraform-kubernetes-addons) and in the customization of the cluster policy
+The main additionals features are the curated addons list, see [here](https://github.com/particuleio/terraform-kubernetes-addons) and in the customization of the cluster policy
 
 ### Enforced security
 
@@ -73,13 +73,13 @@ Terragrunt is not a hard requirement but all the modules are tested with Terragr
 
 ## Additional infrastructure blocks
 
-If you wish to extend your infrastructure you can pick up additional modules on the [clusterfrak-dynamics github page](https://github.com/clusterfrak-dynamics)
+If you wish to extend your infrastructure you can pick up additional modules on the [clusterfrak-dynamics github page](https://github.com/clusterfrak-dynamics) and more recently [particuleio github page](https://github.com/particuleio).
 
 ## Branches
 
-* [`master`](https://github.com/clusterfrak-dynamics/teks/tree/master): Backward incompatible with v1.X but compatible with v2.X, releases bumped to v3.X because a lot has changed.
-* [`release-1.X`](https://github.com/clusterfrak-dynamics/teks/tree/release-1.X): Compatible with Terraform < 0.12 and Terragrunt < 0.19. Be sure to target the same modules version.
-* [`release-2.X`](https://github.com/clusterfrak-dynamics/teks/tree/release-2.X): Compatible with Terraform >= 0.12 and Terragrunt >= 0.19. Be sure to target the same modules version.
+* [`master`](https://github.com/particuleio/teks/tree/master): Backward incompatible with v1.X but compatible with v2.X, releases bumped to v3.X because a lot has changed.
+* [`release-1.X`](https://github.com/particuleio/teks/tree/release-1.X): Compatible with Terraform < 0.12 and Terragrunt < 0.19. Be sure to target the same modules version.
+* [`release-2.X`](https://github.com/particuleio/teks/tree/release-2.X): Compatible with Terraform >= 0.12 and Terragrunt >= 0.19. Be sure to target the same modules version.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ A production cluster all defined in IaaC with Terraform/Terragrunt:
 * EKS cluster base on [`terraform-aws-eks`](https://github.com/terraform-aws-modules/terraform-aws-eks)
 * Kubernetes addons based on [`terraform-kubernetes-addons`](https://github.com/particuleio/terraform-kubernetes-addons): provides various addons that are often used on Kubernetes and specifically on EKS.
 * Kubernetes namespaces quota management based on [`terraform-kubernetes-namespaces`](https://github.com/particuleio/terraform-kubernetes-addons): allows administrator to manage namespaces and quotas from a centralized configuration with Terraform.
-* AWS ECR registries management based on [`terraform-aws-ecr`](https://github.com/particuleio/terraform-aws-ecr)
 
 Everything is tied together with Terragrunt and allows you to deploy a multi cluster architecture in a matter of minutes (ok maybe an hour) and different AWS accounts for different environments.
 


### PR DESCRIPTION
There are still some third party links (Fossa for example) that need to be updated