### PR TITLE
fix: pin eks module version to < 14

### DIFF
--- a/terraform/live/demo/eu-west-3/clusters/full/eks/main.tf
+++ b/terraform/live/demo/eu-west-3/clusters/full/eks/main.tf
@@ -17,7 +17,8 @@ data "aws_eks_cluster_auth" "cluster" {
 }
 
 module "eks" {
-  source = "terraform-aws-modules/eks/aws"
+  source  = "terraform-aws-modules/eks/aws"
+  version = "< 14"
 
   tags = merge(
     local.custom_tags


### PR DESCRIPTION
Version 14 introduces breaking changes regarding the `node_groups` in
aws eks terraform module.

Freeze module version until things settled on their side

Signed-off-by: Theo Bob Massard <tbobm@protonmail.com>