### PR TITLE
docs: explicit terraform backend setup

### DIFF
--- a/docs/user-guides/getting-started.md
+++ b/docs/user-guides/getting-started.md
@@ -31,43 +31,43 @@ The terraform directory structure is the following:
 ```bash
 .
 └── live
-    └── demo
-        ├── common_tags.yaml
-        ├── common_values.yaml
-        ├── eu-west-3
-        │   ├── ecr
-        │   │   ├── provider.tf
-        │   │   └── terragrunt.hcl
-        │   ├── eks
-        │   │   ├── kubeconfig
-        │   │   ├── manifests
-        │   │   │   ├── calico.yaml
-        │   │   │   ├── psp-default-clusterrole.yaml
-        │   │   │   ├── psp-default-clusterrolebinding.yaml
-        │   │   │   ├── psp-default.yaml
-        │   │   │   ├── psp-privileged-clusterrole.yaml
-        │   │   │   ├── psp-privileged-clusterrolebinding.yaml
-        │   │   │   ├── psp-privileged-node-rolebinding.yaml
-        │   │   │   └── psp-privileged.yaml
-        │   │   ├── manifests.tf
-        │   │   ├── providers.tf
-        │   │   └── terragrunt.hcl
-        │   ├── eks-addons
-        │   │   ├── examples
-        │   │   │   ├── keycloak-values.yaml
-        │   │   │   └── kong-values.yaml
-        │   │   ├── providers.tf
-        │   │   └── terragrunt.hcl
-        │   ├── eks-namespaces
-        │   │   ├── providers.tf
-        │   │   └── terragrunt.hcl
-        │   └── vpc
-        │       ├── provider.tf
-        │       └── terragrunt.hcl
-        └── terragrunt.hcl
+    ├── backend
+    │   ├── backend.tf
+    │   ├── providers.tf
+    │   └── state.tf
+    ├── demo
+    │   ├── env_tags.yaml
+    │   └── eu-west-3
+    │       ├── clusters
+    │       │   └── full
+    │       │       ├── eks
+    │       │       │   ├── aws-provider.tf -> ../../../../../shared/aws-provider.tf
+    │       │       │   ├── backend.tf -> ../../../../../backend/backend.tf
+    │       │       │   ├── data.tf
+    │       │       │   ├── locals.tf -> ../../../../../shared/locals.tf
+    │       │       │   └── main.tf
+    │       │       ├── eks-addons
+    │       │       │   ├── aws-provider.tf -> ../../../../../shared/aws-provider.tf
+    │       │       │   ├── backend.tf -> ../../../../../backend/backend.tf
+    │       │       │   ├── data.tf
+    │       │       │   ├── locals.tf -> ../../../../../shared/locals.tf
+    │       │       │   ├── main.tf
+    │       │       │   └── versions.tf
+    │       │       └── vpc
+    │       │           ├── aws-provider.tf -> ../../../../../shared/aws-provider.tf
+    │       │           ├── backend.tf -> ../../../../../backend/backend.tf
+    │       │           ├── locals.tf -> ../../../../../shared/locals.tf
+    │       │           └── main.tf
+    │       └── region_values.yaml
+    ├── global_tags.yaml
+    ├── global_values.yaml
+    └── shared
+        ├── aws-provider.tf
+        └── locals.tf
 ```
 
-Each cluster in inside the `terraform/live` folder and then modules are group by AWS region.
+Each cluster in inside the `terraform/live` folder and then modules are grouped
+by AWS region.
 
 ## Start a new cluster
 
@@ -77,15 +77,70 @@ Create a new cluster beside `demo`:
 cp -ar demo mycluster
 ```
 
-## Configuring Terragrunt remote state
+## Configuring the remote state
 
-`live/demo/terragrunt.hcl` is the parent terragrunt file use to configure remote state.
+Configuration of the remote state is based on the value of the
+`global_values.yaml` file in the `terraform` and the `terragrunt` directories
+based on the installation method you used.
 
-The configuration is done automatically from the `global_values.yaml` file.
+Both files are following the same structure.
 
 ```yaml
 {!terragrunt/live/global_values.yaml!}
 ```
+
+Adapt these values to match your configuration (`prefix`, 'project').
+
+Based on the configuration, both methods will create the following resources:
+
+* S3 bucket named `{prefix}-{project}-{tf|tg}-state`: store the state
+* DynamoDB table named `{prefix}-{project}-{tf|tg}-state-lock`: prevent
+concurrent use
+
+The resource names will include information based on the configuration method
+used. Using `terraform` will create resources with `tf` in their name, and `tg`
+when using `terragrunt`.
+
+Using the current values, the resources created to use `terraform`
+will be:
+
+* S3: `pio-teks-tf-state`
+* DynamoDB: `pio-state-tf-state-lock`
+
+### Remote state for Terraform
+
+If you plan on using terraform to setup `teks`, you need to create your
+remote backend using [cloudposse/terraform-aws-tfstate-backend][tf-aws-tfstate-backend]
+configured in `terraform/live/backend/state.tf`.
+
+In order to configure the S3 backend for terraform, configure your `global_values.yaml`
+then go in the `terraform/live/backend` directory.
+
+* `terraform init` init the terraform module.
+* `terraform apply -auto-approve` to create the S3 backend.
+* `terraform init -force-copy` will copy the local backend to the S3 backend.
+
+The `terraform-aws-tfstate-backend` module will create or update the
+`terraform/live/backend/backend.tf` file, which is symlinked to the child
+modules (`vpc`, `eks`, `eks-addons`).
+
+```json
+{!terraform/live/backend/backend.tf!}
+```
+
+Further documentation regarding the remote backend configuration
+can be found at [terraform-aws-tfstate-backend#create][tf-aws-tfstate-backend#create].
+
+[tf-aws-tfstate-backend]: https://github.com/cloudposse/terraform-aws-tfstate-backend
+[tf-aws-tfstate-backend#create]: https://github.com/cloudposse/terraform-aws-tfstate-backend#create
+
+### Remote state for Terragrunt
+
+`terragrunt/live/demo/terragrunt.hcl` is the parent terragrunt file use
+to configure remote state.
+
+The configuration is done automatically based on the
+`terragrunt/live/global_values.yaml` file.
 
 The values here will generate automatically the parent terragrunt file.
 


### PR DESCRIPTION
:warning: To be merged after #14 

Explicit steps to prepare the repository to use the S3 remote backend.
    
- Define common behaviour between terraform and terragrunt
- Explicit variabilization through `global_values.yaml`
- Recap setup steps for the cloudposse tf-aws-tfstate module
- Fix `tree` output for terraform directory


Closes #13 