### PR TITLE
correct the command in installation doc

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -18,7 +18,7 @@ requirement but our way of managing required tooling.
 ### Enabling plugins
 
 ```
-for p in $(cut -d " " .tool-versions -f1); do asdf plugin add $p; done
+for p in $(cut -d " " -f1 .tool-versions); do asdf plugin-add $p; done
 ```
 
 ### Installing tools


### PR DESCRIPTION
### Issue: Error in Command Using `cut` for Extracting Tool Names from `.tool-versions`

#### **Description:**

An error occurs when using the `cut` command to extract tool names from the `.tool-versions` file. The command is intended to automate adding ASDF plugins based on the tools listed in the `.tool-versions` file.

#### **Original Command:**

```bash
cut -d " " .tool-versions -f1
```

#### **Error Message:**

```plaintext
usage: cut -b list [-n] [file ...]
       cut -c list [file ...]
       cut -f list [-s] [-w | -d delim] [file ...]
```
<img width="706" alt="image" src="https://github.com/user-attachments/assets/0599a6a7-f208-4b0a-9a19-5e56025b1999">

#### **Cause:**

The error occurs because the `cut` command arguments are incorrectly ordered. Specifically, the filename `.tool-versions` is placed before the `-f1` option, leading `cut` to misinterpret the arguments and throw a usage error.

#### **Corrected Command:**

```bash
cut -d " " -f1 .tool-versions
```
<img width="706" alt="image" src="https://github.com/user-attachments/assets/7fce782d-1bcf-4821-8531-0a99d63b67f1">


#### **Explanation:**

- The delimiter (`-d " "`) should be specified before the field (`-f1`).
- The filename (`.tool-versions`) should be placed after all options.
  
This corrects the command, enabling it to properly extract the first field (tool names) from the `.tool-versions` file.

#### **Example Usage with ASDF:**

To automate adding ASDF plugins for each tool listed in `.tool-versions`:

```bash
for p in $(cut -d " " -f1 .tool-versions); do asdf plugin-add $p; done
```
